### PR TITLE
fix for drush moving to github

### DIFF
--- a/definitions/drush.rb
+++ b/definitions/drush.rb
@@ -1,12 +1,20 @@
 define :drush, :drush_bin => '/usr/local/bin' do
 
   drush_root      = node['drupal']['drush']['root']
+
   drush_version   = params[:version] ? params[:version] : nil
   drush_version   ||= params[:name]
+
+  version_parts   = drush_version.split('-').pop.split('.')
+  if version_parts.size < 3
+    version_parts += [0] * (3 - version_parts.size)
+  end
+  drush_version = version_parts.join('.');
+
   drush_path      = "#{drush_root}/#{drush_version}"
   drush_cache     = "#{drush_root}/cache"
   drush_bin       = params[:drush_bin]
-  drush_uri       = "http://ftp.drupal.org/files/projects"
+  drush_uri       = "https://github.com/drush-ops/drush/archive"
   drush_tar       = "#{drush_cache}/drush-#{drush_version}.tar.gz"
   drush_checksum  = params[:checksum]
 
@@ -22,7 +30,7 @@ define :drush, :drush_bin => '/usr/local/bin' do
 
   remote_file drush_tar do
     checksum  drush_checksum
-    source    "#{drush_uri}/drush-#{drush_version}.tar.gz"
+    source    "#{drush_uri}/#{drush_version}.tar.gz"
     mode      "0644"
   end
 


### PR DESCRIPTION
includes fix for legacy version numbers
